### PR TITLE
Adding an optional approval process

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 This repository contains an Issue Template and a GitHub Actions workflow that automates the assignment of GitHub Copilot licenses to users. The workflow is triggered when an issue is labeled with `copilot-request`.
 
+This template works for **GitHub Copilot for Business** and **GitHub Copilot Enterprise**.
+
 ## Objective
 
 The main goal of this repository is to automate the process of assigning GitHub Copilot licenses. Instead of manually assigning licenses, the organization can leverage this solution to simply let the users open an issue using the provided issue template, and the workflow will automatically assign a license to them, when the user opens the issue they are committing to use the GitHub Copilot license.
 
-![GitHub Copilot Logo](https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/GitHub_Copilot_logo.svg/1200px-GitHub_Copilot_logo.svg.png)
+[![GitHub Copilot Logo](https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/GitHub_Copilot_logo.svg/1200px-GitHub_Copilot_logo.svg.png)](https://github.com/features/copilot)
 
 ## How to configure this repository in your organization
 
@@ -24,15 +26,35 @@ The main goal of this repository is to automate the process of assigning GitHub 
 
 ## How users can request a GitHub Copilot License
 
-> Note: At this point GitHub Copilot should be enabled in the organization, the label `copilot-request` should be created and the GitHub App configured with the secrets 'APPLICATION_ID' and 'APPLICATION_PRIVATE_KEY' already stored in the repository.
+> Note: At this point GitHub Copilot should be enabled in the organization, the label `copilot-request` should be created and the GitHub App configured with the secrets `APPLICATION_ID` and `APPLICATION_PRIVATE_KEY` already stored in the repository.
 
 1. Users can now [open a new issue in this repository using the issue template 'Request GitHub Copilot License'](/../../issues/new?assignees=&labels=copilot-request&projects=&template=github_copilot_request.md&title=Request+GitHub+Copilot+License).
 3. The workflow will be triggered automatically and if successful, a GitHub Copilot license will be assigned to the user's account.
 
-## Issue Template
+## (Optional) Add an approval process to the license assignment
+
+One of the easiest way to add an approval process to the GitHub Copilot license assignment is by following the following steps:
+
+1. Create a new environment in the repository. Go to `Settings`, then `Environments` and click on `New environment`. Provide a name to the environment, for example, `Copilot` or `copilot-request-approval`.
+2. In the environment settings, check the `Required reviewers` option and add the users that will be able to approve the requests. (You can add up to 6 users).
+3. In the workflow file [assign_github_copilot_license.yml](/.github/workflows/assign_github_copilot_license.yml), add `environment: <name of your environment>`, in the job that assigns the GitHub Copilot (line 8), for example:
+
+```yaml
+6. jobs:
+7.    assign_github_copilot_license:
+8.       environment: Copilot
+```
+
+Now, when a user opens an issue with the label `copilot-request`, the workflow will wait for the approval of the users added to the environment before assigning the GitHub Copilot license.
+
+## Repository Content
+
+The repository contains the following files:
+
+### 1. Issue Template
 
 The issue template [Request GitHub Copilot License](/.github/ISSUE_TEMPLATE/github_copilot_request.md) is provided to standardize the license request process. The template uses the label `copilot-request` to trigger the workflow that assigns GitHub Copilot licenses, this label needs to be created in the repository before opening an issue. The template contains a notice to the user about the commitment they're making by requesting the GitHub Copilot license, informing the user about what will happen once their license request is fulfilled, a motivational message for the user, and a thank you note to the user.
 
-## GitHub Action Workflow
+### 2. GitHub Action Workflow
 
 The workflow [assign_github_copilot_license.yml](/.github/workflows/assign_github_copilot_license.yml) is triggered when an issue is labeled with `copilot-request`.  The workflow uses the [GitHub API](https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#add-users-to-the-copilot-subscription-for-an-organization) through [octokit](http://octokit.github.io/) to assign the GitHub Copilot license to the user who opened the issue. A token is generated using [Peter Murray's Action](https://github.com/peter-murray/workflow-application-token-action). Upon successful execution, the workflow comments on the issue and closes it. In case of failure, it comments on the issue to notify about the failure and leaves the issue open. The workflow uses the [GITHUB_TOKEN](https://docs.github.com/actions/reference/authentication-in-a-workflow) to comment and close the issue opened by the user. The execution of the workflow takes less than 1 minute.


### PR DESCRIPTION
This pull request includes changes to the `README.md` file to improve the documentation of the GitHub Copilot license assignment process. The most significant changes involve expanding the scope of the template to cover both GitHub Copilot for Business and GitHub Copilot Enterprise, adding an optional approval process for license assignment, and reformatting the document for better readability.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5-R11): The scope of the template has been expanded to include both **GitHub Copilot for Business** and **GitHub Copilot Enterprise**. This change clarifies that the template is not limited to a specific version of GitHub Copilot.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5-R11): The GitHub Copilot logo now links to the official GitHub Copilot page. This change provides a quick and easy way for users to learn more about GitHub Copilot.

Optional approval process:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R58): An optional approval process for the GitHub Copilot license assignment has been added. This process involves creating a new environment in the repository, adding required reviewers to the environment, and modifying the workflow file. This change allows organizations to have more control over the license assignment process.

Documentation reformatting:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R58): The document has been reformatted for better readability. The "Issue Template" and "GitHub Action Workflow" sections have been moved under a new "Repository Content" section, and the note about the prerequisites for the license request process has been formatted as a blockquote.