### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github_copilot_license_management.yml
+++ b/.github/workflows/github_copilot_license_management.yml
@@ -5,6 +5,11 @@ on:
     types:
       - labeled
 
+# Limit the default GITHUB_TOKEN permissions to the minimum required
+permissions:
+  issues: write
+  contents: read
+
 # This workflow uses the GitHub Token to comment on the issues and close them
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/GitHubCopilotLicenseAssignment/security/code-scanning/4](https://github.com/microsoft/GitHubCopilotLicenseAssignment/security/code-scanning/4)

To fix this, explicitly declare minimal `permissions` for the workflow so that the automatically provided `GITHUB_TOKEN` does not inherit broad repository defaults. Both jobs need to read issues and write comments and change issue state; they do not need general `contents` write access. The Copilot license operations use a separate GitHub App token, so they don’t affect `GITHUB_TOKEN` permissions. The best fix is to add a root-level `permissions` block that applies to all jobs and grants only what is needed: read access where required and `issues: write` for commenting/closing issues. No changes to step logic are needed.

Concretely, in `.github/workflows/github_copilot_license_management.yml`, add a `permissions` section after the `name:` (and before `on:` or just after `on:`; both are valid) specifying `issues: write`. Since the workflow is triggered by issues events, it may also be reasonable to leave `contents` unspecified (which will default to `read` when any permission block is present) or explicitly include `contents: read` for clarity. This will satisfy CodeQL and keep the workflow’s behavior unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
