### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github_copilot_license_management.yml
+++ b/.github/workflows/github_copilot_license_management.yml
@@ -1,4 +1,10 @@
 name: GitHub Copilot License Management
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
 # This workflow is triggered when an issue is labeled
 on:
   issues:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/GitHubCopilotLicenseAssignment/security/code-scanning/3](https://github.com/microsoft/GitHubCopilotLicenseAssignment/security/code-scanning/3)

To fix this, explicitly declare a `permissions` block so that the implicit broad defaults are no longer used. The safest, least‑privilege approach is to define `permissions` at the workflow (top) level so it applies to both jobs, and grant only what the jobs actually need: they comment on and close issues (requires `issues: write`) and run code via actions (requires `actions: read` at minimum). They do not modify repository contents, so `contents` can be set to `read` or omitted (defaults to `none` if not specified when a `permissions` block is present).

The concrete change: in `.github/workflows/github_copilot_license_management.yml`, add a `permissions` block right after the `name:` line (before `on:`). Set `issues: write` to allow creating comments and closing issues, and set `contents: read` (a conservative, commonly used baseline) plus `actions: read` if you want to be explicit. This does not change any existing functionality, because those scopes are sufficient for the current API calls; the Copilot billing API uses the GitHub App token, not the default `GITHUB_TOKEN`. No other parts of the file need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
